### PR TITLE
Add  oasys-mainnet mch-verse network ID

### DIFF
--- a/src/verify-number.ts
+++ b/src/verify-number.ts
@@ -92,12 +92,20 @@ export class VerifyNumber {
         networkName = "bsc-testnet";
         break;
       case 336:
-          networkName = "shiden-mainnet";
+        networkName = "shiden-mainnet";
+        break;
       case 81:
         networkName = "shiden-shibuya";
         break;
       case 11421:
         networkName = "jcbi";
+        break;
+      case 248:
+        networkName = "oasys-mainnet";
+        break;
+      case 29548:
+        networkName = "mch-verse";
+        break;
     }
 
     try {


### PR DESCRIPTION
# 対応内容
oasysとmch-verse 上のNet WorkIdを新たに追加してます。

# 対応理由
oasysとmch-verse ネットワークを切り替えた状態で、マイクリにログインしたいため